### PR TITLE
feat(Server-Side Rendering): deploy React InstantSearch on Heroku 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,22 @@ jobs:
       - checkout
       - deploy_project:
           path: "dynamic-rendering/instantsearch.js"
-          app_name: "is-seo-dynamic-routing-0"
+          app_name: "is-seo-dynamic-routing-0b"
+
+  build_server_side_rendering:
+    executor: node9
+    steps:
+      - checkout
+      - build_project:
+          path: "server-side-rendering/react-instantsearch"
+
+  deploy_server_side_rendering:
+    executor: node9
+    steps:
+      - checkout
+      - deploy_project:
+          path: "server-side-rendering/react-instantsearch"
+          app_name: "is-seo-ssr-react-0"
 
   build_client_side_rendering_js:
     executor: node9
@@ -75,6 +90,13 @@ workflows:
       - deploy_dynamic_rendering:
           requires:
             - build_dynamic_rendering
+          filters:
+            branches:
+              only: master
+      - build_server_side_rendering
+      - deploy_server_side_rendering:
+          requires:
+            - build_server_side_rendering
           filters:
             branches:
               only: master

--- a/dynamic-rendering/instantsearch.js/README.md
+++ b/dynamic-rendering/instantsearch.js/README.md
@@ -1,7 +1,7 @@
 # Dynamic rendering with instantsearch.js
 
 ### Demo
-This demo is deployed on https://is-seo-dynamic-routing-0.herokuapp.com/
+This demo is deployed on https://is-seo-dynamic-routing-0b.herokuapp.com/
 This demo get automatically deployed every time you merge to master.
 
 ### Run this for development

--- a/server-side-rendering/react-instantsearch/.gitignore
+++ b/server-side-rendering/react-instantsearch/.gitignore
@@ -9,6 +9,7 @@
 # production
 /dist/server.js
 /dist/static/bundle.js
+/dist/static/bundle.js.map
 
 # misc
 .DS_Store

--- a/server-side-rendering/react-instantsearch/README.md
+++ b/server-side-rendering/react-instantsearch/README.md
@@ -1,21 +1,16 @@
 # Server-Side Rendering with React InstantSearch
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
+This demo is deployed on https://is-seo-ssr-react-0.herokuapp.com/
+
+This demo get automatically deployed every time you merge to master.
 
 ## Get started
 
 To run this project locally, install the dependencies and run the local server:
 
 ```sh
-npm install
-npm start
-```
-
-Alternatively, you may use [Yarn](https://http://yarnpkg.com/):
-
-```sh
 yarn
-yarn start
+yarn dev
 ```
 
 Open http://localhost:3000 to see your app.

--- a/server-side-rendering/react-instantsearch/package.json
+++ b/server-side-rendering/react-instantsearch/package.json
@@ -2,9 +2,11 @@
   "name": "ssr-react-instantsearch",
   "version": "1.0.0",
   "private": true,
+  "main": "dist/server",
   "scripts": {
-    "start": "npm run build; nodemon --watch dist/server.js dist/server & npm run build -- --watch",
-    "build": "webpack",
+    "start": "node .",
+    "dev": "webpack; nodemon --watch dist/server.js & webpack --watch",
+    "build": "NODE_ENV=production webpack",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "npm run lint -- --fix",
     "type-check": "tsc",

--- a/server-side-rendering/react-instantsearch/webpack.config.js
+++ b/server-side-rendering/react-instantsearch/webpack.config.js
@@ -3,6 +3,11 @@
 const path = require('path');
 const nodeExternals = require('webpack-node-externals');
 
+/*
+ * Configure the environment
+ */
+const ENV = process.env.NODE_ENV || 'development';
+
 module.exports = [
   /*
    * Client entrypoint
@@ -15,7 +20,11 @@ module.exports = [
       publicPath: '/',
       filename: 'bundle.js',
     },
-    mode: 'development',
+    mode: ENV,
+    devtool:
+      ENV === 'production'
+        ? 'module-source-map'
+        : 'cheap-module-inline-source-map',
     target: 'web',
     resolve: {
       /*
@@ -62,7 +71,7 @@ module.exports = [
       libraryTarget: 'commonjs2',
       publicPath: '/',
     },
-    mode: 'development',
+    mode: ENV,
     target: 'node',
     node: {
       __dirname: true,


### PR DESCRIPTION
This change updates the server-side rendering implementation to deploy it on Heroku.

For this a few changes were made:

* Update Webpack configuration to get a development and a production build
* Update `npm start` script to start the production server
* Update `npm run build` script to build in production mode
* Add `npm run dev` script to build, start the server and watch for changes (was previously done with `npm start`)
* Add `build_server_side_rendering` and `deploy_server_side_rendering` jobs in CircleCI configuration
* Rename the Dynamic Rendering application to `is-seo-dynamic-routing-0b` (since @tkrugg is in holidays he could not invite me to his project so I had to use my heroku account and create a new one)